### PR TITLE
NodegroupName attribute to align with other template references.

### DIFF
--- a/templates/amazon-eks-nodegroup.template.yaml
+++ b/templates/amazon-eks-nodegroup.template.yaml
@@ -274,7 +274,7 @@ Resources:
     Type: Custom::CliQuery
     Properties:
       ServiceToken: !Sub ['arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${Prefix}-ResourceReader', {Prefix: !FindInMap [Config, Prefix, Value]}]
-      AwsCliCommand: !Sub "autoscaling describe-auto-scaling-groups --query 'AutoScalingGroups[? Tags[? Key==`eks:cluster-name` && Value==`${EKSClusterName}`] && Tags[? Key==`eks:nodegroup-name` && Value==`${ManagedNodeGroup}`]] | [0] | {Id: AutoScalingGroupName}'"
+      AwsCliCommand: !Sub "autoscaling describe-auto-scaling-groups --query 'AutoScalingGroups[? Tags[? Key==`eks:cluster-name` && Value==`${EKSClusterName}`] && Tags[? Key==`eks:nodegroup-name` && Value==`${ManagedNodeGroup.NodegroupName}`]] | [0] | {Id: AutoScalingGroupName}'"
       IdField: 'Id'
   NodeImageId:
     Condition: UseSSmAmi


### PR DESCRIPTION
Using `${ManagedNodeGroup}` in the `ManagedASG` resource causes the filter to not match. `${ManagedNodeGroup}` resolves to `<ClusterName>/<NodeGroupName>`. However the tag on the EKS cluster only uses `<NodeGroupName>`. 

This PR modified the CLI command to use the `NodegroupName` attribute of the `AWS::EKS::NodeGroup` resource. 

Closes #6 

`EKS-XSMAFHA3/Default` vs `Default`

Existing behavior
```
❯ aws autoscaling describe-auto-scaling-groups --query 'AutoScalingGroups[? Tags[? Key==`eks:cluster-name` && Value==`EKS-XSMAFHA3`] && Tags[? Key==`eks:nodegroup-name` && Value==`EKS-XSMAFHA3/Default`]] | [0] | {Id: AutoScalingGroupName}' --output json
null
```

Modified behavior
```
❯ aws autoscaling describe-auto-scaling-groups --query 'AutoScalingGroups[? Tags[? Key==`eks:cluster-name` && Value==`EKS-XSMAFHA3`] && Tags[? Key==`eks:nodegroup-name` && Value==`Default`]] | [0] | {Id: AutoScalingGroupName}' --output json
{
    "Id": "eks-f4baa3f5-94df-e625-6a92-d08fa62fd932"
}
```