### PR TITLE
added role arn for cfn signal

### DIFF
--- a/templates/amazon-eks-nodegroup.template.yaml
+++ b/templates/amazon-eks-nodegroup.template.yaml
@@ -452,7 +452,8 @@ Resources:
                     /opt/aws/bin/cfn-signal --exit-code $1 \
                       --stack  ${AWS::StackName} \
                       --resource UnmanagedASG  \
-                      --region ${AWS::Region}
+                      --region ${AWS::Region} \
+                      --role ${NodeRoleArn}
                   }
                   ${ProxySetup}
                   /etc/eks/bootstrap.sh ${EKSClusterName} ${ExtraArgs} \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. When a node group for EKS Cluster is created with type 'AWS::EKS::NodeGroup' (Managed Node Group). EKS Creates a new AutoScaling Group with custom tags and do not add information related to CloudFormation Stack.
2. CloudFormation stack allows permission to send `cfn-signal` from EC2 nodes that are directly managed by CloudFormation. Example: CloudFormation stack creates ASG and ASG creates EC2 instances.
3. Because, EKS Managed Node Group does not create a CloudFormation stack and do not add any tags to created ec2 instances about Parent CloudFormation stack. `cfn-signal` command fail with following error.

```
# tail -20 /var/log/cfn-wire.log 
2021-01-29 03:47:19,883 [DEBUG] Response: 400 https://cloudformation.us-west-2.amazonaws.com/?Status=SUCCESS&ContentType=JSON&StackName=<REDACTED>&Version=2010-05-15&UniqueId=i-02cb07e334b22ee5c&Action=SignalResource&LogicalResourceId=UnmanagedASG [headers: {'x-amzn-requestid': '<REMOVED>', 'date': 'Fri, 29 Jan 2021 03:47:18 GMT', 'content-length': '124', 'content-type': 'application/json', 'connection': 'close'}]
```

In order to address this issue, `cfn-signal` command should be executed with `--role` flag by passing IAM role name of the EC2 instance. This pull request will update `cfn-signal` command to use `--role` flag.

Please note, I have not tested these changes. Please test it and merge the PR.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
