### PR TITLE
version: removed deprecated windows ami option

### DIFF
--- a/templates/amazon-eks-nodegroup.template.yaml
+++ b/templates/amazon-eks-nodegroup.template.yaml
@@ -192,8 +192,8 @@ Parameters:
     Description: 'The edition of Windows AMI to use for Windows Nodegroups.'
   WindowsVersion:
     Type: String
-    AllowedValues: ['2004', '2019']
-    Default: '2004'
+    AllowedValues: ['2019']
+    Default: '2019'
     Description: 'The version of windows to use for Windows Nodegroups.'
   EC2MetadataPutResponseHopLimit:
     Type: String


### PR DESCRIPTION
*Description of changes:* Windows 2004 AMI version was deprecated in December 2021

Ref: https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2-windows-ami-version-history.html

Windows Server 2022 and EC2LaunchV2-* AMIs

EC2Launch v2 version 2.0.674

Windows Server 2004 reached End-of-support on December 14th, 2021. All public versions of the following images have been made private. Existing instances and custom images owned by your account that are based on Windows Server 2004 will not be impacted.

Windows_Server-2004-English-Core-Base

Windows_Server-2004-English-Core-ContainersLatest


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
