### PR TITLE
Add Windows Server 2022 and set as default version

### DIFF
--- a/templates/amazon-eks-nodegroup.template.yaml
+++ b/templates/amazon-eks-nodegroup.template.yaml
@@ -764,9 +764,9 @@ Parameters:
     Description: 'The edition of Windows AMI to use for Windows Nodegroups.'
   WindowsVersion:
     Type: String
-    AllowedValues: ['2019']
-    Default: '2019'
-    Description: 'The version of windows to use for Windows Nodegroups.'
+    Description: The version of windows to use for Windows Nodegroups.
+    AllowedValues: [2019, 2022]
+    Default: 2022
   EC2MetadataPutResponseHopLimit:
     Type: String
     Default: "1"


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-quickstart/quickstart-amazon-eks/pull/491

*Description of changes:*
* The EBS CSI driver is mandatory for EKS 1.23+ and only supports Windows Server 2022+ starting in v1.12+: <https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
